### PR TITLE
ELF.append_symbol: return index of newly added symbol

### DIFF
--- a/makeelf/elf.py
+++ b/makeelf/elf.py
@@ -465,6 +465,9 @@ class ELF:
         # if local update sh_info to symbol id plus one
         symtab_hdr.sh_info = sym_id + 1
 
+        # return index of new symbol
+        return sym_id
+
 
 class ELFTests(unittest.TestCase):
 


### PR DESCRIPTION
Some structures (e.g. relocation) require this index, and we already have it conveniently in a variable