### PR TITLE
Replace bytes_xor with much faster numpy based version

### DIFF
--- a/makeelf/utils.py
+++ b/makeelf/utils.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
 ## \file utils.py
 #  \brief Utility functions
+
+# Old code was quite slow on large files (e.g., several seconds on a 32MB ELF).
+# Most of this was xor.  Large speedup from this SO answer:
+#https://stackoverflow.com/questions/2119761/simple-python-challenge-fastest-bitwise-xor-on-data-buffers
+#
+# Although, this does add numpy as a dependency, so perhaps this should be checked at runtime?
+from numpy import frombuffer, bitwise_xor, byte
+
 def bytes_xor(lhs, rhs):
-    res = []
-    for a, b in zip(lhs, rhs):
-        res.append(a ^ b)
-    return bytes(res)
+    a = frombuffer(lhs, dtype=byte)
+    b = frombuffer(rhs, dtype=byte)
+    c = bitwise_xor(a, b)
+    r = c.tostring()
+    return bytes(r)


### PR DESCRIPTION
Hi, I was using your code on some fairly large files and writing out the ELF was quite slow.  Most of this was in bytes_xor(), so I found a faster implementation using numpy.

If you don't want the numpy dependency, that's perfectly understandable.  Perhaps this could be refactored so it uses the fast version if numpy is already available.

I did very little testing - just checking that for the files I was working with, SHA1 was the same with old vs fast implementation of bytes_xor().