### PR TITLE
Link program headers to sections

### DIFF
--- a/makeelf/elfstruct.py
+++ b/makeelf/elfstruct.py
@@ -544,7 +544,7 @@ class PF(Enum):
 class Elf32_Phdr:
 
     def __init__(self, p_type=0, p_offset=0, p_vaddr=0, p_paddr=0, p_filesz=0,
-            p_memsz=0, p_flags=0, p_align=0, little=False):
+                 p_memsz=0, p_flags=0, p_align=0, little=False, sections=None):
         ## Type of segment
         self.p_type = p_type
         ## Offset in file, where first byte of segment resides
@@ -567,6 +567,10 @@ class Elf32_Phdr:
         #  \details Is true, if header values are meant to be stored as
         #  little-endian or false otherwise
         self.little = little
+
+        ## Sections linked to this segment
+        #  \details List of Section IDs contained within this segment
+        self.sections = sections or []
 
     def __str__(self):
         return '{p_type=%s, p_offset=%s, p_vaddr=%s, p_paddr=%s, ' \

--- a/makeelf/test_elf.py
+++ b/makeelf/test_elf.py
@@ -55,3 +55,22 @@ class ELFTests(unittest.TestCase):
 
         h,a = invector.get_section_by_name('.dynamic')
         self.assertEqual(expected, actual)
+
+    def test_phdr(self):
+        data = b"TESTTEST"
+        elf = ELF()
+        section = elf.append_section("test", data, 0x12345678)
+        phdr = elf._append_segment(PT.PT_LOAD, 0xDEADBEEF, 0xC0FFEE, len(data), len(data), PF.PF_R, [section])
+        actual = bytes(elf)
+
+        self.assertEqual(elf.Elf.Phdr_table[phdr].p_offset, elf.Elf.Shdr_table[section].sh_offset)
+
+        expected = bytes.fromhex("""
+            7f454c4601020100000000000000000000020000000000010000000000000034000000740000000000340020000200280003
+            0001000000010000000000000000000000000000000000000000000000050000000100000001000000fcdeadbeef00c0ffee
+            0000000800000008000000040000000100000000000000000000000000000000000000ec0000000000000000000000000000
+            00000000000000000001000000030000000000000000000000ec00000010000000000000000000000001000000000000000b
+            000000010000000012345678000000fc0000000800000000000000000000000100000000002e736873747274616200746573
+            74005445535454455354
+        """)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Allow the caller to specify a section to associate a program header to.
This will allow the ELF writer to determine a correct file offset for
the program header (the file offset of the lowest associated section).